### PR TITLE
File system paths and image.load calls

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -1,8 +1,9 @@
 import sys
+import os
 import xml.etree.ElementTree as etree
 from xml.dom.minidom import parseString
 
-sys.path.append("roguey/classes")
+sys.path.append(os.path.join("roguey", "classes"))
 
 from items import Treasure
 from constants import *
@@ -15,7 +16,13 @@ def prettify(element):
 class Admin(object):
 	def __init__(self):
 		# Load the existing treasures
-		f = open("roguey/resources/items.xml")
+		f = open(
+			os.path.join(
+				"roguey",
+				"resources",
+				"items.xml",
+				)
+			)
 		self.treasures = etree.fromstring(f.read())
 		f.close()
 		# trim the annoying whitespace...
@@ -24,7 +31,13 @@ class Admin(object):
 			element.text = element.text.strip()
 			element.tail = ""
 		# Load the list of treasure type templates
-		f = open("roguey/resources/item_templates.xml")
+		f = open(
+			os.path.join(
+				"roguey",
+				"resources",
+				"item_templates.xml",
+				)
+			)
 		self.treasure_templates = etree.fromstring(f.read())
 		f.close()
 		# Enter main loop

--- a/roguey/classes/constants.py
+++ b/roguey/classes/constants.py
@@ -1,4 +1,4 @@
-from os.path import abspath, dirname
+from os.path import abspath, dirname, join, sep
 
 MOVEMENT_SIZE = 12
 RADIUS = 2
@@ -20,6 +20,9 @@ for treasure in EQUIPMENT_TYPES:
 
 TREASURE_TYPES = ('hat', 'shirt', 'pants', 'shoes', 'back', 'neck', 'hands', 'weapon', 'trash')
 
-IMG_DIR = dirname(dirname(abspath(__file__))) + "/images/"
+IMG_DIR = join(
+	dirname(dirname(abspath(__file__))),
+	"images"
+	) + sep
 
 STATS = ('strength', 'attack', 'defense')

--- a/roguey/classes/gamescreen.py
+++ b/roguey/classes/gamescreen.py
@@ -13,7 +13,11 @@ class GameScreen(object):
         self.small_font = pygame.font.SysFont(None, 20)
         self.bg = pygame.image.load(IMG_DIR + 'rainbowbg.png')
         self.player_blit = pygame.image.load(IMG_DIR + 'dude.png')
+        self.monster_blit = pygame.image.load(IMG_DIR + 'dumb_monster.png')
         self.selection_blit = pygame.image.load(IMG_DIR + 'selection.png')
+        self.treasure_blit = pygame.image.load(IMG_DIR + 'chest.png')
+        self.wall_tile = pygame.image.load(IMG_DIR + 'wall.png')
+        self.floor_tile = pygame.image.load(IMG_DIR + 'floor.png')
         self.screen.blit(self.bg, (0,0))
         self.inventory_screen = self.small_font.render("Inventory", True, WHITE, BLACK)
         self.equipment_screen = self.small_font.render("Equipment", True, WHITE, BLACK)
@@ -106,8 +110,9 @@ class GameScreen(object):
         for row in range(ROWS):
             for col in range(COLUMNS):
                 if treasure_map[row][col] != 0:
-                    treasure = pygame.image.load(IMG_DIR + 'chest.png')
-                    self.screen.blit(treasure, (row*TILE_SIZE, col*TILE_SIZE))
+                    self.screen.blit(
+                        self.treasure_blit,
+                        (row*TILE_SIZE, col*TILE_SIZE))
     
     def draw_monsters(self, map):
         ''' Draws monsters that appear in the area that the rogue can see
@@ -116,17 +121,17 @@ class GameScreen(object):
             for col in range(COLUMNS):
                 #if map.monsters[row][col] != 0 and map.current[row][col] != 0:
                 if map.monsters[row][col] != 0:
-                    monster = pygame.image.load(IMG_DIR + 'dumb_monster.png')
-                    self.screen.blit(monster, (row*TILE_SIZE, col*TILE_SIZE))
+                    self.screen.blit(
+                        self.monster_blit,
+                        (row*TILE_SIZE, col*TILE_SIZE))
     
-    def draw_walls(self, walls, filename):
+    def draw_walls(self, walls, tile):
         ''' Draws walls on the game map
         '''
         for row in range(ROWS):
             for col in range(COLUMNS):
                 if walls[row][col] != 0:
-                    wall = pygame.image.load(IMG_DIR + filename)
-                    self.screen.blit(wall, (row*TILE_SIZE, col*TILE_SIZE))
+                    self.screen.blit(tile, (row*TILE_SIZE, col*TILE_SIZE))
 
     def draw_darkness(self, map):
         ''' Draws the darkness and shadows on the board. 0 is dark, 1 is in shadows,
@@ -171,8 +176,8 @@ class GameScreen(object):
         ''' Draws the layers of the game screen
         '''
         self.draw_background()
-        self.draw_walls(map.floor, 'floor.png')
-        self.draw_walls(map.walls, 'wall.png')
+        self.draw_walls(map.floor, self.floor_tile)
+        self.draw_walls(map.walls, self.wall_tile)
         self.draw_treasure(map.treasure)
         self.draw_monsters(map)
         #self.draw_darkness(map)


### PR DESCRIPTION
A little fix to make file system paths cross platform. Hard coding them as "/images/" or whatever won't work for systems that don't use the forward slashes (ie. Windows) so I've used `os.path.join` instead.

Also I went ahead and moved the `pygame.image.load` calls out of the game loop and into `Gamescreen.__init__`. The game seems to be much more responsive now.
