### PR TITLE
docs: Fix a few typos

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -132,7 +132,7 @@ class Admin(object):
 		# Print out the numbered options
 		for i, option in enumerate(options):
 			print "%3s. %s" % (i+1, option)
-		# Continue to prompt user until valid input is recieved.
+		# Continue to prompt user until valid input is received.
 		while retval == None:
 			# Get the users selection
 			selection = raw_input("%s: " % prompt)

--- a/roguey/classes/items.py
+++ b/roguey/classes/items.py
@@ -13,14 +13,14 @@ class Treasure(object):
         self.description = description
         self.item_type = item_type
 
-        # The rest of the attibutes are optional depending on the item type
+        # The rest of the attributes are optional depending on the item type
         [setattr(self, key, value) for key, value in kwargs.iteritems()]
         
     @classmethod
     def from_xml(cls, xml):
         """
         Creates a Treasure object from an etree XML object.
-        Treasures can have abitrary attribute but must always have
+        Treasures can have arbitrary attribute but must always have
         the required attributes, 'title', 'description', 'item_type'.
         If the XML element describing a Treasure attribute has
         a "type" attribute in its XML tag, this can be used to convert


### PR DESCRIPTION
There are small typos in:
- admin.py
- roguey/classes/items.py

Fixes:
- Should read `received` rather than `recieved`.
- Should read `attributes` rather than `attibutes`.
- Should read `arbitrary` rather than `abitrary`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md